### PR TITLE
Fix the patches for Pass It Through The Window

### DIFF
--- a/Mods and Shit/Pass It Through/Patches/pass it through patch.xml
+++ b/Mods and Shit/Pass It Through/Patches/pass it through patch.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-    <Operation Class="PatchOperationRemove">
-        <xpath>Defs/ThingDef[defName="PassThroughWindow"]/researchPrerequisites</xpath>
-    </Operation>
-
-    <Operation Class="PatchOperationRemove">
-        <xpath>Defs/ResearchProjectDef[defName="PassThroughWindowResearch"]</xpath>
-    </Operation>
-
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="PassThroughWindow"]</xpath>
-        <value>
-            <designationCategory>ASFstorage</designationCategory>
-        </value>
-    </Operation>
-    <Operation Class="PatchOperationReplace">
-        <xpath>Defs/ThingDef[defName="PassThroughWindow"]/costList</xpath>
-        <value>
-            <costList>
-                <Steel>20</Steel>
-            </costList>
-        </value>
-    </Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="PassThroughWindow"]</xpath>
+    <value>
+      <designationCategory>ASFstorage</designationCategory>
+    </value>
+  </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="PassThroughWindow"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>20</Steel>
+      </costList>
+    </value>
+  </Operation>
 
 </Patch>


### PR DESCRIPTION
The author of Pass It Through The Window removed their own research project in favor of just using ComplexFurniture instead. The description of the mod says it allows transfer of items without transferring temperature, so it's basically a window with shutters or some other closing mechanism, somewhat analogous to a vent, which also uses ComplexFurniture as a prerequisite. 

So I've removed the patch operations that remove the now defunct research project and the prerequisites for building the pass through window. Obviously if you'd prefer it to not have any research prerequisite at all you can put that patch operation back.